### PR TITLE
ZNTA-1148 Use MySQL 5.7 and UTF-8

### DIFF
--- a/zanata-server/rundb.sh
+++ b/zanata-server/rundb.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 docker run --name zanatadb \
   -e MYSQL_USER=zanata -e MYSQL_PASSWORD=password -e MYSQL_DATABASE=zanata -e MYSQL_RANDOM_ROOT_PASSWORD=yes \
-  -d mariadb:10.1
-echo 'Please use the command "docker logs zanatadb" to check that MariaDB starts correctly.'
+  -d mysql:5.7 \
+  --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+
+echo 'Please use the command "docker logs zanatadb" to check that MySQL starts correctly.'


### PR DESCRIPTION
Until https://jira.mariadb.org/browse/MDEV-9646 is implemented, this is the only way to index large varchar fields without code changes to Zanata (or Liquibase) if you want real UTF-8.

https://zanata.atlassian.net/browse/ZNTA-1148

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/docker-images/4)

<!-- Reviewable:end -->
