### PR TITLE
ZNTA-1148 Use utf8 (but not utf8mb)

### DIFF
--- a/zanata-server/rundb.sh
+++ b/zanata-server/rundb.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 docker run --name zanatadb \
   -e MYSQL_USER=zanata -e MYSQL_PASSWORD=password -e MYSQL_DATABASE=zanata -e MYSQL_RANDOM_ROOT_PASSWORD=yes \
-  -d mariadb:10.1
+  -d mariadb:10.1 \
+  --character-set-server=utf8 --collation-server=utf8_general_ci
+
 echo 'Please use the command "docker logs zanatadb" to check that MariaDB starts correctly.'


### PR DESCRIPTION
This will allow a wider range of Unicode characters to be stored by Zanata. 

NB: Supplementary Unicode characters are not supported by the so-called "utf8" encoding, but switching to utf8mb will require code changes in Zanata (or MariaDB 10.2, or MySQL 5.7).

See also #4 and https://zanata.atlassian.net/browse/ZNTA-1148

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/docker-images/5)

<!-- Reviewable:end -->
