### PR TITLE
Use realpath instead of readlink for MacOS compability

### DIFF
--- a/zanata-server/runapp.sh
+++ b/zanata-server/runapp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-ScriptDir=$(dirname $(readlink -f $0))
+ScriptDir=$(dirname $(realpath $0))
 
 if [ -n "${ZANATA_VERSION-}" ];then
     ## Use the version from set environment ZANATA_VERSION

--- a/zanata-server/rundb.sh
+++ b/zanata-server/rundb.sh
@@ -15,7 +15,7 @@ if [ -z $(docker ps -aq -f name=zanatadb) ];then
     docker run --name zanatadb \
         -e MYSQL_USER=${ZANATA_MYSQL_USER} -e MYSQL_PASSWORD=${ZANATA_MYSQL_PASSWORD} \
         -e MYSQL_DATABASE=${ZANATA_MYSQL_DATABASE} -e MYSQL_RANDOM_ROOT_PASSWORD=yes \
-        -v zanata-db:/var/lib/mysql:z \
+        -v zanata-db:/var/lib/mysql:Z \
         -d mariadb:10.1 \
         --character-set-server=utf8 --collation-server=utf8_general_ci
 elif [ -n $(docker ps -aq -f name=zanatadb -f status=exited) ];then


### PR DESCRIPTION
Part of https://zanata.atlassian.net/browse/ZNTA-1660
ZNTA-1660: Update docker script to avoid 'chcon' error

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-docker-files/17)
<!-- Reviewable:end -->
