### PR TITLE
Adding DB_PORTNUMBER

### DIFF
--- a/zanata-server/Dockerfile
+++ b/zanata-server/Dockerfile
@@ -8,9 +8,13 @@ EXPOSE 8080
 ARG ZANATA_VERSION=4.3.1
 ARG MYSQL_CONNECTOR_JAVA_VERSION=5.1.26
 
+# Database Setup
+ENV DB_HOSTNAME zanatadb
+ENV DB_PORTNUMBER 3306
+
 # MAIL_USERNAME and MAIL_PASSWORD can not be empty as they are used in wildfly standalone-full.xml.
 # If the smtp server does not require authentication, these single space values will be used
-ENV DB_HOSTNAME=zanatadb MAIL_HOST=localhost MAIL_USERNAME=' ' MAIL_PASSWORD=' '
+ENV MAIL_HOST=localhost MAIL_USERNAME=' ' MAIL_PASSWORD=' '
 
 # Fedora Containers Packaging may need this
 LABEL Name="zanata-platform"\

--- a/zanata-server/conf/standalone.xml
+++ b/zanata-server/conf/standalone.xml
@@ -184,7 +184,7 @@
         <subsystem xmlns="urn:jboss:domain:datasources:4.0">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/zanataDatasource" pool-name="zanataDatasource" enabled="true" use-ccm="true">
-                    <connection-url>jdbc:mysql://${env.DB_HOSTNAME}:3306/${env.DB_SCHEMA}?characterEncoding=UTF-8</connection-url>
+                    <connection-url>jdbc:mysql://${env.DB_HOSTNAME}:${env.DB_PORTNUMBER}/${env.DB_SCHEMA}?characterEncoding=UTF-8</connection-url>
                     <driver-class>com.mysql.jdbc.Driver</driver-class>
                     <driver>mysql-connector-java.jar</driver>
                     <pool>

--- a/zanata-server/docker-compose.yml
+++ b/zanata-server/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     environment:
       - ZANATA_HOME=/var/lib/zanata
       - DB_HOSTNAME=zanatadb
+      - DB_PORTNUMBER=3306
       - DB_SCHEMA=$ZANATA_MYSQL_DATABASE
       - DB_USERNAME=$ZANATA_MYSQL_USER
       - DB_PASSWORD=$ZANATA_MYSQL_PASSWORD


### PR DESCRIPTION
This PR adds the possibility to use a non-default port.
In my case it is useful, because my Synology NAS uses a more recent MariaDB at a different port than 3306.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-docker-files/28)
<!-- Reviewable:end -->
