### PR TITLE
Making use of ZANATA_MGMT in standalone.xml

### DIFF
--- a/zanata-server/conf/standalone.xml
+++ b/zanata-server/conf/standalone.xml
@@ -588,7 +588,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public"
         port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-http" interface="management"
-            port="${jboss.management.http.port:9990}" />
+            port="${env.ZANATA_MGMT:9990}" />
         <socket-binding name="management-https" interface="management"
             port="${jboss.management.https.port:9993}" />
         <socket-binding name="management-native" interface="management"


### PR DESCRIPTION
Otherwise port 9990 will be still used after setting ZANATA_MGMT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-docker-files/29)
<!-- Reviewable:end -->
