### PR TITLE
ZNTA-2525 - Remove subfolder in path docker container

### DIFF
--- a/zanata-server/Dockerfile
+++ b/zanata-server/Dockerfile
@@ -38,8 +38,8 @@ USER jboss
 RUN curl -L -o /opt/jboss/wildfly/standalone/deployments/mysql-connector-java.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_JAVA_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}.jar
 
 # Zanata war
-RUN curl -L -o /opt/jboss/wildfly/standalone/deployments/zanata.war \
+RUN curl -L -o /opt/jboss/wildfly/standalone/deployments/ROOT.war \
     https://github.com/zanata/zanata-platform/releases/download/platform-${ZANATA_VERSION}/zanata-war-${ZANATA_VERSION}.war \
-    && chmod o+rw /opt/jboss/wildfly/standalone/deployments/zanata.war
+    && chmod o+rw /opt/jboss/wildfly/standalone/deployments/ROOT.war
 
 ADD conf/standalone.xml /opt/jboss/wildfly/standalone/configuration/


### PR DESCRIPTION
Refs https://zanata.atlassian.net/browse/ZNTA-2525

Actually the war is named `zanata`, this mean that by default che webserver expose it as a subfolder that generate some issue using the tool (broken link & c). Actually to fix it we should include some redirect in a proxy before the webserver, but this introduce some complexity that is not needed; also using docker container is a good practice having only one application running (and exposed) so have subfolder is not useful at all.