### PR TITLE
Set the LANG environment variable to en_US.UTF-8 in the zanata-server Dockerfile

### DIFF
--- a/zanata-server/Dockerfile
+++ b/zanata-server/Dockerfile
@@ -43,3 +43,6 @@ RUN curl -L -o /opt/jboss/wildfly/standalone/deployments/ROOT.war \
     && chmod o+rw /opt/jboss/wildfly/standalone/deployments/ROOT.war
 
 ADD conf/standalone.xml /opt/jboss/wildfly/standalone/configuration/
+
+# Set the server locale so that UTF-8 documents can be uploaded
+ENV LANG en_US.UTF-8


### PR DESCRIPTION
Set the LANG environment variable to en_US.UTF-8 in the zanata-server Dockerfile.

Without the locale set, when uploading UTF-8 documents containing foreign characters these aren't stored correctly in the database.

For example, upload a file containing the word "Français" and in the app the translation source will be displayed as "Fran��ais"